### PR TITLE
Fix exception when switching to full screen video

### DIFF
--- a/spaces/overlay.js
+++ b/spaces/overlay.js
@@ -13,6 +13,6 @@ setEventHandler ( 'spaceDidChange', () => {
 
   if ( index === -1 ) return;
 
-  alert ( spacesListRaw.items[index].title, undefined, SPACES_OVERLAY_DURATION );
+  alert ( _.get(spacesListRaw, ['items', index, 'title'], 'Full Screen'), undefined, SPACES_OVERLAY_DURATION );
 
 });


### PR DESCRIPTION
This little PR aims to fix I bug I've encountered: whenever I switch to full-screen video, i.e. double-clicking the video in youtube, etc, an exception is raised.

The proposed fix would handle the exception and display 'Full Screen' instead using [`_.get`](https://lodash.com/docs/4.17.11#get)