### PR TITLE
Fix issues with multi monitor support in setAnchor

### DIFF
--- a/helpers/center_window.js
+++ b/helpers/center_window.js
@@ -4,7 +4,7 @@
 function center_window ( window ) {
 
   const screen = window.screen (),
-        sFrame = screen.frame (),
+        sFrame = screen.flippedFrame (),
         wFrame = window.frame ();
 
   window.setFrame ({

--- a/helpers/grow_frame.js
+++ b/helpers/grow_frame.js
@@ -15,10 +15,11 @@ function growFrame ( x, y, width, height, window = Window.focused () ) {
   //FIXME: We are leveraging the fact that in the current use case `x` and `y` are always negatives, while `width` and `height` are always positives
 
   if ( x ) newFrame.x = _.clamp ( frame.x + x, sFrame.x, sFrame.x + sFrame.width );
-  if ( y ) newFrame.y = _.clamp ( frame.y + y, yUnusable, yUnusable + svFrame.height );
-  if ( width ) newFrame.width = Math.min ( x ? frame.x + frame.width : sFrame.width - frame.x, frame.width + ( width - ( Math.abs ( x ) - Math.abs ( frame.x - newFrame.x ) ) ) );
-  if ( height ) newFrame.height = Math.min ( y ? frame.y + frame.height : sFrame.height - frame.y, frame.height + ( height - ( Math.abs ( y ) - Math.abs ( frame.y - newFrame.y ) ) ) );
+  if ( y ) newFrame.y = _.clamp ( frame.y + y, yUnusable + sFrame.y, yUnusable + sFrame.y + svFrame.height );
+  if ( width ) newFrame.width = Math.min ( x ? frame.x - sFrame.x + frame.width : sFrame.width - (frame.x - sFrame.x), frame.width + ( width - ( Math.abs ( x ) - Math.abs ( frame.x - newFrame.x ) ) ) );
+  if ( height ) newFrame.height = Math.min ( y ? frame.y + frame.height : sFrame.height - (frame.y - sFrame.y), frame.height + ( height - ( Math.abs ( y ) - Math.abs ( frame.y - newFrame.y ) ) ) );
 
+  log(sFrame.height, frame.y)
   window.setFrame ( newFrame );
 
 }

--- a/helpers/set_anchor.js
+++ b/helpers/set_anchor.js
@@ -14,8 +14,8 @@ function setAnchor ( x, y, window = Window.focused () ) {
         wFrame = window.frame ();
 
   const nextFrame = {
-    x: x === 0 ? 0 : ( x === 1 ? frame.width - wFrame.width : wFrame.x ),
-    y: y === 0 ? 0 : ( y === 1 ? frame.height - wFrame.height : wFrame.y ),
+    x: x === 0 ? frame.x : ( x === 1 ? (frame.x + frame.width - wFrame.width) : wFrame.x ),
+    y: y === 0 ? frame.y : ( y === 1 ? (frame.y + frame.height - wFrame.height) : wFrame.y ),
     width: wFrame.width,
     height: wFrame.height
   };


### PR DESCRIPTION
The set anchor function had a bug in that it did not account for the fact that
phoenix may have negative values for x and y in some multi monitor situations.
To resolve the issue, I replaced all areas where set anchor assumed the left
most or top most value would be 0 with calls to frame.x and frame.y

I believe this may fix bug #3, but since there weren't a lot of details in that bug 
I'm not sure.